### PR TITLE
Support fixed filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ bin/behat -f cucumber_json
 
 - `fileNamePrefix`: Filename prefix of generated report
 - `outputDir`: Generated report will be placed in this directory
+- `fileName` _(optional)_: Filename of generated report - current feature name will be used by default.
 
 ## Licence
 

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -39,6 +39,7 @@ class Extension implements ExtensionInterface
     {
         $builder->children()->scalarNode('fileNamePrefix')->defaultValue('report');
         $builder->children()->scalarNode('outputDir')->defaultValue('build/tests');
+        $builder->children()->scalarNode('fileName');
     }
 
     /**
@@ -51,6 +52,10 @@ class Extension implements ExtensionInterface
 
         $definition->addArgument($config['fileNamePrefix']);
         $definition->addArgument($config['outputDir']);
+
+        if (!empty($config['fileName'])) {
+          $definition->addMethodCall('setFileName', [$config['fileName']]);
+        }
 
         $container
             ->setDefinition('json.formatter', $definition)

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -54,7 +54,7 @@ class Extension implements ExtensionInterface
         $definition->addArgument($config['outputDir']);
 
         if (!empty($config['fileName'])) {
-          $definition->addMethodCall('setFileName', [$config['fileName']]);
+            $definition->addMethodCall('setFileName', [$config['fileName']]);
         }
 
         $container

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -74,6 +74,11 @@ class Formatter implements FormatterInterface
     }
 
     /** @inheritdoc */
+    public function setFileName($fileName) {
+      $this->printer->setResultFileName($fileName);
+    }
+
+    /** @inheritdoc */
     public function getDescription()
     {
         return 'Cucumber style formatter';
@@ -123,13 +128,16 @@ class Formatter implements FormatterInterface
         $this->timer->stop();
 
         $this->renderer->render();
-        $this->printer->setResultFileName(
-            str_replace(
-                DIRECTORY_SEPARATOR,
-                FileOutputPrinter::FILE_SEPARATOR,
-                $this->currentFeature->getFilenameForReport()
-            )
-        );
+        if (!$this->printer->getResultFileName()) {
+          $this->printer->setResultFileName(
+              str_replace(
+                  DIRECTORY_SEPARATOR,
+                  FileOutputPrinter::FILE_SEPARATOR,
+                  $this->currentFeature->getFilenameForReport()
+              )
+          );
+        }
+
         $this->printer->write($this->renderer->getResult());
     }
 

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -307,7 +307,7 @@ class Formatter implements FormatterInterface
         $arguments = [];
         foreach ($result->getSearchResult()->getMatchedArguments() as $argument) {
             $a = new \stdClass();
-            $a->val = $argument;
+            $a->val = (string) $argument;
             $arguments[] = $a;
         }
         if ($arguments) {

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -75,7 +75,7 @@ class Formatter implements FormatterInterface
 
     /** @inheritdoc */
     public function setFileName($fileName) {
-      $this->printer->setResultFileName($fileName);
+        $this->printer->setResultFileName($fileName);
     }
 
     /** @inheritdoc */
@@ -129,13 +129,13 @@ class Formatter implements FormatterInterface
 
         $this->renderer->render();
         if (!$this->printer->getResultFileName()) {
-          $this->printer->setResultFileName(
-              str_replace(
-                  DIRECTORY_SEPARATOR,
-                  FileOutputPrinter::FILE_SEPARATOR,
-                  $this->currentFeature->getFilenameForReport()
-              )
-          );
+            $this->printer->setResultFileName(
+                str_replace(
+                    DIRECTORY_SEPARATOR,
+                    FileOutputPrinter::FILE_SEPARATOR,
+                    $this->currentFeature->getFilenameForReport()
+                )
+            );
         }
 
         $this->printer->write($this->renderer->getResult());

--- a/src/Formatter/FormatterInterface.php
+++ b/src/Formatter/FormatterInterface.php
@@ -13,4 +13,11 @@ interface FormatterInterface extends FormatterOutputInterface
      * @return Suite[]
      */
     public function getSuites();
+
+    /**
+     * Set a fixed filename, which will override the current feature filename.
+     *
+     * @param $fileName
+     */
+    public function setFileName($fileName);
 }

--- a/src/Printer/FileOutputPrinter.php
+++ b/src/Printer/FileOutputPrinter.php
@@ -73,6 +73,14 @@ class FileOutputPrinter implements OutputPrinterInterface
         $this->resultFileName = $resultFileName;
     }
 
+    /**
+     * @return string
+     */
+    public function getResultFileName()
+    {
+      return $this->resultFileName;
+    }
+
     /** @inheritdoc */
     public function getOutputPath()
     {

--- a/src/Printer/FileOutputPrinter.php
+++ b/src/Printer/FileOutputPrinter.php
@@ -78,7 +78,7 @@ class FileOutputPrinter implements OutputPrinterInterface
      */
     public function getResultFileName()
     {
-      return $this->resultFileName;
+        return $this->resultFileName;
     }
 
     /** @inheritdoc */


### PR DESCRIPTION
We need to be able to have a fixed report filename (as per original project).

I’ve added an optional `fileName` configuration (for backwards compatibility) to allow the filename to be a fixed value.

We also had an issue where some values where output as empty JSON `{}` objects causing problems with 
https://github.com/jenkinsci/cucumber-reports-plugin - this was solved by casting all values to strings.

Let me know if there’s a preferable way to solve this.