### PR TITLE
Add configurable support of outputing a reportfile per suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ php:
   - 7.0
   - 7.1
 
-before_script: composer install --prefer-source --no-interaction
+before_script: COMPOSER_MEMORY_LIMIT=-1 composer install --prefer-source --no-interaction
 
 script: composer run-script test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Behat Cucumber Json Formatter 
+# Behat Cucumber Json Formatter
 
 *Note*: this is a fork of [Vanare/behat-cucumber-formatter](https://github.com/Vanare/behat-cucumber-formatter). As the original project seems unmaintained and there is no possibility to contact the owner, I publish the library under my handle. Many thanks to the original team of Vanare for starting this great library!
 
@@ -27,6 +27,7 @@ default:
     extensions:
         Vanare\BehatCucumberJsonFormatter\Extension:
             fileNamePrefix: report
+            resultFilePerSuite: true
             outputDir: %paths.base%/build/tests
 ```
 
@@ -41,6 +42,9 @@ bin/behat -f cucumber_json
 - `fileNamePrefix`: Filename prefix of generated report
 - `outputDir`: Generated report will be placed in this directory
 - `fileName` _(optional)_: Filename of generated report - current feature name will be used by default.
+Only applicable when `resultFilePerSuite` is not enabled.
+- `resultFilePerSuite` _(optional)_: The default behaviour is to generate a single report named `all.json`.
+If this option is set to `true`, a report will be created per behat suite.
 
 ## Licence
 

--- a/features/enable-output-per-suite.feature
+++ b/features/enable-output-per-suite.feature
@@ -1,0 +1,46 @@
+Feature: Calculator example
+
+  Scenario: Default to only output a single result file
+    Given I have the following feature:
+      """
+      Feature: Calculator
+
+      Scenario: Adding numbers
+      Given I have numbers 1 and 2
+      When I sum the numbers
+      Then I should have 3 as result
+      """
+    And I have the following feature file "eat-cukes.feature" stored in "otherfeatures":
+      """
+      Feature: Eat cukes in lot
+
+      Scenario: Eating many cukes
+      Given I have 10 cukes
+      When I eat 5 cukes
+      Then Am I hungry? false
+      """
+    When I run behat with the converter
+    Then 1 result file should be generated
+
+  Scenario: Output to a result file per suite
+    Given I have the enabled the "resultFilePerSuite" option
+    And I have the following feature:
+      """
+      Feature: Calculator
+
+      Scenario: Adding numbers
+      Given I have numbers 1 and 2
+      When I sum the numbers
+      Then I should have 3 as result
+      """
+    And I have the following feature file "eat-cukes.feature" stored in "otherfeatures":
+      """
+      Feature: Eat cukes in lot
+
+      Scenario: Eating many cukes
+      Given I have 10 cukes
+      When I eat 5 cukes
+      Then Am I hungry? false
+      """
+    When I run behat with the converter
+    Then 2 result files should be generated

--- a/features/enable-output-per-suite.feature
+++ b/features/enable-output-per-suite.feature
@@ -10,7 +10,7 @@ Feature: Calculator example
       When I sum the numbers
       Then I should have 3 as result
       """
-    And I have the following feature file "eat-cukes.feature" stored in "otherfeatures":
+    And I have the following feature file "eat-cukes.feature" stored in "othersuite":
       """
       Feature: Eat cukes in lot
 
@@ -19,8 +19,9 @@ Feature: Calculator example
       When I eat 5 cukes
       Then Am I hungry? false
       """
-    When I run behat with the converter
+    When I run behat with the converter and no specific suite is specified
     Then 1 result file should be generated
+    And there should be 2 features in the report "report-all.json"
 
   Scenario: Output to a result file per suite
     Given I have the enabled the "resultFilePerSuite" option
@@ -33,7 +34,7 @@ Feature: Calculator example
       When I sum the numbers
       Then I should have 3 as result
       """
-    And I have the following feature file "eat-cukes.feature" stored in "otherfeatures":
+    And I have the following feature file "eat-cukes.feature" stored in "othersuite":
       """
       Feature: Eat cukes in lot
 
@@ -42,5 +43,7 @@ Feature: Calculator example
       When I eat 5 cukes
       Then Am I hungry? false
       """
-    When I run behat with the converter
+    When I run behat with the converter and no specific suite is specified
     Then 2 result files should be generated
+    And there should be 1 feature in the report "report-default.json"
+    And there should be 1 feature in the report "report-othersuite.json"

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -40,6 +40,7 @@ class Extension implements ExtensionInterface
         $builder->children()->scalarNode('fileNamePrefix')->defaultValue('report');
         $builder->children()->scalarNode('outputDir')->defaultValue('build/tests');
         $builder->children()->scalarNode('fileName');
+        $builder->children()->booleanNode('resultFilePerSuite')->defaultFalse();
     }
 
     /**
@@ -56,6 +57,7 @@ class Extension implements ExtensionInterface
         if (!empty($config['fileName'])) {
             $definition->addMethodCall('setFileName', [$config['fileName']]);
         }
+        $definition->addMethodCall('setResultFilePerSuite', [$config['resultFilePerSuite']]);
 
         $container
             ->setDefinition('json.formatter', $definition)

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -37,7 +37,7 @@ class Extension implements ExtensionInterface
      */
     public function configure(ArrayNodeDefinition $builder)
     {
-        $builder->children()->scalarNode('fileNamePrefix')->defaultValue('report');
+        $builder->children()->scalarNode('fileNamePrefix')->defaultValue('');
         $builder->children()->scalarNode('outputDir')->defaultValue('build/tests');
         $builder->children()->scalarNode('fileName');
         $builder->children()->booleanNode('resultFilePerSuite')->defaultFalse();

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -139,7 +139,7 @@ class Formatter implements FormatterInterface
 
         if ($this->resultFilePerSuite) {
             foreach ($this->suites as $suite) {
-                $this->printer->setResultFileName('report-' . $suite->getName());
+                $this->printer->setResultFileName($suite->getFilenameForReport());
                 $suiteResult = $this->renderer->getResultForSuite($suite->getName());
                 $this->printer->write($suiteResult);
             }
@@ -147,13 +147,7 @@ class Formatter implements FormatterInterface
         }
 
         if (!$this->printer->getResultFileName()) {
-            $this->printer->setResultFileName(
-                str_replace(
-                    DIRECTORY_SEPARATOR,
-                    FileOutputPrinter::FILE_SEPARATOR,
-                    $this->currentFeature->getFilenameForReport()
-                )
-            );
+            $this->printer->setResultFileName('all');
         }
 
         $this->printer->write($this->renderer->getResult());

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -43,6 +43,9 @@ class Formatter implements FormatterInterface
     /** @var Node\Scenario */
     private $currentScenario;
 
+    /** @var bool */
+    private $resultFilePerSuite = false;
+
     /**
      * @param string $fileNamePrefix
      * @param string $outputDir
@@ -76,6 +79,11 @@ class Formatter implements FormatterInterface
     /** @inheritdoc */
     public function setFileName($fileName) {
         $this->printer->setResultFileName($fileName);
+    }
+
+    /** @inheritdoc */
+    public function setResultFilePerSuite(bool $enabled) {
+        $this->resultFilePerSuite = $enabled;
     }
 
     /** @inheritdoc */
@@ -128,6 +136,16 @@ class Formatter implements FormatterInterface
         $this->timer->stop();
 
         $this->renderer->render();
+
+        if ($this->resultFilePerSuite) {
+            foreach ($this->suites as $suite) {
+                $this->printer->setResultFileName('report-' . $suite->getName());
+                $suiteResult = $this->renderer->getResultForSuite($suite->getName());
+                $this->printer->write($suiteResult);
+            }
+            return;
+        }
+
         if (!$this->printer->getResultFileName()) {
             $this->printer->setResultFileName(
                 str_replace(

--- a/src/Node/Feature.php
+++ b/src/Node/Feature.php
@@ -195,14 +195,6 @@ class Feature
     }
 
     /**
-     * @return string
-     */
-    public function getFilenameForReport()
-    {
-        return dirname($this->file) . FileOutputPrinter::FILE_SEPARATOR . basename($this->file, '.feature');
-    }
-
-    /**
      * @return Scenario[]
      */
     public function getScenarios()

--- a/src/Node/Suite.php
+++ b/src/Node/Suite.php
@@ -53,4 +53,12 @@ class Suite
     {
         $this->features[] = $feature;
     }
+
+    /**
+     * @return string
+     */
+    public function getFilenameForReport()
+    {
+        return $this->getName();
+    }
 }

--- a/src/Renderer/JsonRenderer.php
+++ b/src/Renderer/JsonRenderer.php
@@ -32,7 +32,7 @@ class JsonRenderer implements RendererInterface
 
         if (is_array($suites)) {
             foreach ($suites as $suite) {
-                array_push($this->result, $this->processSuite($suite));
+                $this->result[$suite->getName()] = $this->processSuite($suite);
             }
         }
     }
@@ -45,6 +45,19 @@ class JsonRenderer implements RendererInterface
         }
 
         return $this->result;
+    }
+
+    public function getResultForSuite($suiteName, $asString = true)
+    {
+        $result = null;
+        if (isset($this->result[$suiteName])) {
+            $result = $this->result[$suiteName];
+        }
+
+        if ($asString) {
+            return json_encode($result);
+        }
+        return $result;
     }
 
     /**

--- a/src/Renderer/JsonRenderer.php
+++ b/src/Renderer/JsonRenderer.php
@@ -41,7 +41,11 @@ class JsonRenderer implements RendererInterface
     public function getResult($asString = true)
     {
         if ($asString) {
-            return json_encode(array_pop($this->result));
+            $mergedResults = [];
+            foreach ($this->result as $result) {
+                $mergedResults = array_merge($mergedResults, $result);
+            }
+            return json_encode($mergedResults);
         }
 
         return $this->result;

--- a/src/Renderer/RendererInterface.php
+++ b/src/Renderer/RendererInterface.php
@@ -16,4 +16,13 @@ interface RendererInterface
      * @return array|string
      */
     public function getResult($asString);
+
+    /**
+     * Returns the JSON result as an array or string representation for a suite with a given name.
+     *
+     * @param string $suiteName
+     * @param bool $asString
+     * @return array|string
+     */
+    public function getResultForSuite($suiteName, $asString);
 }


### PR DESCRIPTION
Opening a PR to start a discussion around how to solve the output naming and results of the current behat-cucumber-formatter extension. This PR should close issue #4.

This PR is backwards-compatible and doesn't change anything to the current behaviour of the extension, a report file named by the name of the suite can be generated by specifying the option `resultFilePerSuite: true` in the extension configuration.
I do however find the current implementation a bit "odd", and I wonder if there is room to make further improvements here?
The main issues I see are summarised below.

1. The default filename is weird, it's based on the last feature tested in the default suite, but it contains all features in the default suite. Is there a specific reason to why it behaves this way currently?

Example:
I have a default suite with two feature files "calculator.feature" and "eat-cukes.feature".
I run the test suite with the command `behat -s default -f cucumber_json`.
The generated report contains the results from `calculator.feature` and `eat-cukes.feature`, but the report is named `report-tmp-behat-a9cf46741df008fe789ae0a7de708413-features-default-eat-cukes.json` which seems like an overly complex and strange default to me?

2. The current behaviour is that if you have multiple suites defined and don't specify the suite when you run the tests, then the cucumber json formatter only writes the result of the last run suite to the report file. As a user I would expect that the report file would contain all the tests that Behat ran.


Would be good to get some feedback on these topics and the implementation to see how it can progress next :) 