### PR TITLE
Take screenshots and insert them in the json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ bin/behat -f cucumber_json
 - `fileName` _(optional)_: Filename of generated report - current feature name will be used by default.
 Only applicable when `resultFilePerSuite` is not enabled.
 - `resultFilePerSuite` _(optional)_: The default behaviour is to generate a single report named `all.json`.
-- `screenshotExtension` _(optional)_: The name of the extension to be used to take screenshots.
 If this option is set to `true`, a report will be created per behat suite.
+- `screenshotExtension` _(optional)_: The name of the extension to be used to take screenshots.
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ default:
             fileNamePrefix: report
             resultFilePerSuite: true
             outputDir: %paths.base%/build/tests
+            screenshotExtension: Bex\Behat\ScreenshotExtension
 ```
 
 Then you can run:
@@ -48,6 +49,7 @@ bin/behat -f cucumber_json
 - `fileName` _(optional)_: Filename of generated report - current feature name will be used by default.
 Only applicable when `resultFilePerSuite` is not enabled.
 - `resultFilePerSuite` _(optional)_: The default behaviour is to generate a single report named `all.json`.
+- `screenshotExtension` _(optional)_: The name of the extension to be used to take screenshots.
 If this option is set to `true`, a report will be created per behat suite.
 
 ## Licence

--- a/features/calculator.feature
+++ b/features/calculator.feature
@@ -54,7 +54,8 @@ Feature: Calculator example
                   "result": {
                     "duration": 12345,
                     "status": "passed"
-                  }
+                  },
+                  "embeddings": []
                 },
                 {
                   "keyword": "When",
@@ -66,7 +67,8 @@ Feature: Calculator example
                   "result": {
                     "duration": 12345,
                     "status": "passed"
-                  }
+                  },
+                  "embeddings": []
                 },
                 {
                   "keyword": "Then",
@@ -83,7 +85,8 @@ Feature: Calculator example
                   "result": {
                     "duration": 12345,
                     "status": "passed"
-                  }
+                  },
+                  "embeddings": []
                 }
               ],
               "type": "scenario"

--- a/features/eat-cukes.feature
+++ b/features/eat-cukes.feature
@@ -51,7 +51,8 @@ Feature: Eat cukes Example
                       }
                     ],
                     "location": "ExampleFeatureContext::passing1()"
-                  }
+                  },
+                  "embeddings": []
                 },
                 {
                   "result": {
@@ -68,7 +69,8 @@ Feature: Eat cukes Example
                       }
                     ],
                     "location": "ExampleFeatureContext::eat()"
-                  }
+                  },
+                  "embeddings": []
                 },
                 {
                   "result": {
@@ -85,7 +87,8 @@ Feature: Eat cukes Example
                       }
                     ],
                     "location": "ExampleFeatureContext::hungry()"
-                  }
+                  },
+                  "embeddings": []
                 }
               ],
               "type": "scenario_outline"
@@ -112,7 +115,8 @@ Feature: Eat cukes Example
                       }
                     ],
                     "location": "ExampleFeatureContext::passing1()"
-                  }
+                  },
+                  "embeddings": []
                 },
                 {
                   "result": {
@@ -129,7 +133,8 @@ Feature: Eat cukes Example
                       }
                     ],
                     "location": "ExampleFeatureContext::eat()"
-                  }
+                  },
+                  "embeddings": []
                 },
                 {
                   "result": {
@@ -147,7 +152,8 @@ Feature: Eat cukes Example
                       }
                     ],
                     "location": "ExampleFeatureContext::hungry()"
-                  }
+                  },
+                  "embeddings": []
                 }
               ],
               "type": "scenario_outline"
@@ -174,7 +180,8 @@ Feature: Eat cukes Example
                       }
                     ],
                     "location": "ExampleFeatureContext::passing1()"
-                  }
+                  },
+                  "embeddings": []
                 },
                 {
                   "result": {
@@ -191,7 +198,8 @@ Feature: Eat cukes Example
                       }
                     ],
                     "location": "ExampleFeatureContext::eat()"
-                  }
+                  },
+                  "embeddings": []
                 },
                 {
                   "result": {
@@ -209,7 +217,8 @@ Feature: Eat cukes Example
                       }
                     ],
                     "location": "ExampleFeatureContext::hungry()"
-                  }
+                  },
+                  "embeddings": []
                 }
               ],
               "type": "scenario_outline"
@@ -236,7 +245,8 @@ Feature: Eat cukes Example
                       }
                     ],
                     "location": "ExampleFeatureContext::passing1()"
-                  }
+                  },
+                  "embeddings": []
                 },
                 {
                   "result": {
@@ -253,7 +263,8 @@ Feature: Eat cukes Example
                       }
                     ],
                     "location": "ExampleFeatureContext::eat()"
-                  }
+                  },
+                  "embeddings": []
                 },
                 {
                   "result": {
@@ -270,7 +281,8 @@ Feature: Eat cukes Example
                       }
                     ],
                     "location": "ExampleFeatureContext::hungry()"
-                  }
+                  },
+                  "embeddings": []
                 }
               ],
               "type": "scenario_outline"

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -53,6 +53,7 @@ class Extension implements ExtensionInterface
               // Check if the configuration for the screenshot extension matches the namespace of the service.
               if (strpos(get_class($service), $config['screenshotExtension']) !== false) {
                 $imageUploaderService = $service;
+                break;
               }
             }
           }

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -91,6 +91,21 @@ class Formatter implements FormatterInterface
       $this->files[] = $event->getFilename();
     }
 
+    /**
+     * Attaches screenshots to steps.
+     */
+    private function attachScreenshots() {
+      array_reverse($this->files);
+      foreach ($this->currentScenario->getSteps() as &$step) {
+        if ($step->getResultCode() !== 0) {
+          $file = array_pop($this->files);
+          if (!empty($file)) {
+            $step->addEmbedding($file);
+          }
+        }
+      }
+    }
+
     /** @inheritdoc */
     public function setFileName($fileName): void
     {
@@ -242,18 +257,7 @@ class Formatter implements FormatterInterface
             $this->currentFeature->addPassedScenario();
         } else {
             $this->currentFeature->addFailedScenario();
-            // Attach screenshots.
-            array_reverse($this->files);
-            $i=0;
-            foreach ($this->currentScenario->getSteps() as &$step) {
-                if ($step->getResultCode() !== 0) {
-                    $file = array_pop($this->files);
-                    if (!empty($file)) {
-                        $step->addEmbedding($file);
-                    }
-                }
-                $i++;
-            }
+            $this->attachScreenshots();
         }
 
         $this->currentScenario->setPassed($event->getTestResult()->isPassed());
@@ -300,6 +304,7 @@ class Formatter implements FormatterInterface
                 $this->currentFeature->addPassedScenario();
             } else {
                 $this->currentFeature->addFailedScenario();
+                $this->attachScreenshots();
             }
 
             $example->setPassed($scenarioPassed);

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -88,13 +88,18 @@ class Formatter implements FormatterInterface
         return;
       }
 
+      $steps = $this->currentScenario->getSteps();
+      if (empty($steps)) {
+        return;
+      }
+
       $files = $this->screenshotService->getImages();
       if (empty($files)) {
         return;
       }
-
       array_reverse($files);
-      foreach ($this->currentScenario->getSteps() as &$step) {
+
+      foreach ($steps as &$step) {
         if ($step->getResultCode() !== 0) {
           $file = array_pop($files);
           if (!empty($file)) {

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -53,7 +53,7 @@ class Formatter implements FormatterInterface
      */
     private $screenshotService;
 
-    public function __construct(string $fileNamePrefix, string $outputDir, $screenshotService)
+    public function __construct(string $fileNamePrefix, string $outputDir, $screenshotService = null)
     {
         $this->renderer = new JsonRenderer($this);
         $this->printer = new FileOutputPrinter($fileNamePrefix, $outputDir);

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -89,6 +89,10 @@ class Formatter implements FormatterInterface
       }
 
       $files = $this->screenshotService->getImages();
+      if (empty($files)) {
+        return;
+      }
+
       array_reverse($files);
       foreach ($this->currentScenario->getSteps() as &$step) {
         if ($step->getResultCode() !== 0) {

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -15,7 +15,7 @@ use Vanare\BehatCucumberJsonFormatter\Node;
 use Vanare\BehatCucumberJsonFormatter\Printer\FileOutputPrinter;
 use Vanare\BehatCucumberJsonFormatter\Renderer\JsonRenderer;
 use Vanare\BehatCucumberJsonFormatter\Renderer\RendererInterface;
-use Bex\Behat\ScreenshotExtension\Event\ScreenshotUploaderEvent;
+use Bex\Behat\ScreenshotExtension\Event\ScreenshotUploadCompleteEvent;
 
 class Formatter implements FormatterInterface
 {
@@ -75,16 +75,16 @@ class Formatter implements FormatterInterface
             BehatEvent\OutlineTested::AFTER => 'onAfterOutlineTested',
             BehatEvent\StepTested::BEFORE => 'onBeforeStepTested',
             BehatEvent\StepTested::AFTER => 'onAfterStepTested',
-            ScreenshotUploaderEvent::UPLOAD => 'screenshotUploaded',
+            ScreenshotUploadCompleteEvent::NAME => 'screenshotUploaded',
         ];
     }
 
     /**
      * Keeps track of uploaded screenshots to add to json output.
      *
-     * @param ScreenshotUploaderEvent $event
+     * @param ScreenshotUploadCompleteEvent $event
      */
-    public function screenshotUploaded(ScreenshotUploaderEvent $event) {
+    public function screenshotUploaded(ScreenshotUploadCompleteEvent $event) {
       if (empty($event->getFilename())) {
         return;
       }

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -248,7 +248,6 @@ class Formatter implements FormatterInterface
             foreach ($this->currentScenario->getSteps() as &$step) {
                 if ($step->getResultCode() !== 0) {
                     $file = array_pop($this->files);
-                    var_dump('file ' , $file);
                     if (!empty($file)) {
                         $step->addEmbedding($file);
                     }

--- a/src/Node/Step.php
+++ b/src/Node/Step.php
@@ -78,7 +78,7 @@ class Step
     /**
      * @var array
      */
-    private $files = [];
+    private $embeddings = [];
 
     /**
      * @var ?Definition
@@ -175,24 +175,19 @@ class Step
      */
     public function getEmbeddings()
     {
-      $embeddings = [];
-      foreach ($this->files as $url) {
-        $embeddings[] = [
+      return $this->embeddings;
+    }
+
+    /**
+     * @param string $url
+     */
+    public function addEmbedding($url)
+    {
+        $this->embeddings[] = [
           'mime_type' => 'image/url',
           'name' => 'Screenshot.jpg',
           'data' => base64_encode($url)
         ];
-      }
-
-      return $embeddings;
-    }
-
-    /**
-     * @param array $files
-     */
-    public function setFiles($files)
-    {
-        $this->files = $files;
     }
 
     /**

--- a/src/Node/Step.php
+++ b/src/Node/Step.php
@@ -185,7 +185,7 @@ class Step
     {
         $this->embeddings[] = [
           'mime_type' => 'image/url',
-          'name' => 'Screenshot.jpg',
+          'name' => 'Screenshot',
           'data' => base64_encode($url)
         ];
     }

--- a/src/Node/Step.php
+++ b/src/Node/Step.php
@@ -76,6 +76,11 @@ class Step
     private $output;
 
     /**
+     * @var array
+     */
+    private $files = [];
+
+    /**
      * @var ?Definition
      */
     private $definition;
@@ -163,6 +168,31 @@ class Step
     public function setLine(int $line): void
     {
         $this->line = $line;
+    }
+
+    /**
+     * @return array
+     */
+    public function getEmbeddings()
+    {
+      $embeddings = [];
+      foreach ($this->files as $url) {
+        $embeddings[] = [
+          'mime_type' => 'image/url',
+          'name' => 'Screenshot.jpg',
+          'data' => base64_encode($url)
+        ];
+      }
+
+      return $embeddings;
+    }
+
+    /**
+     * @param array $files
+     */
+    public function setFiles($files)
+    {
+        $this->files = $files;
     }
 
     /**

--- a/src/Renderer/JsonRenderer.php
+++ b/src/Renderer/JsonRenderer.php
@@ -150,6 +150,7 @@ class JsonRenderer implements RendererInterface
             'line' => $step->getLine(),
             'match' => $step->getMatch(),
             'result' => $step->getProcessedResult(),
+            'embeddings' => $step->getEmbeddings(),
         ];
     }
 


### PR DESCRIPTION
Issue https://github.com/cawolf/behat-cucumber-formatter/issues/10

**What it does**
- Introduces a new configuration to specify the Behat extension that provides screenshots
- The container will first find services with tag id `screenshot.service` and compare the class vs configuration
- Updated readme
- Keeps track of files for each step
- Sends the files to json output

**Testing**
Add these entries on `composer.json`

```
  "repositories": [
    {
      "type": "vcs",
      "url": "https://github.com/marcelovani/behat-screenshot.git"
    },
    {
      "type": "vcs",
      "url": "https://github.com/marcelovani/behat-cucumber-formatter.git"
    }
  ],
```

then

```
  "require-dev": {
    "cawolf/behat-cucumber-json-formatter": "dev-10-screenshots-support",
    "bex/behat-screenshot": "dev-61-event-dispatcher-breaking-formatter"
  }
```

**Screenshot**
<img width="1159" alt="Screenshot 2022-11-30 at 00 46 02" src="https://user-images.githubusercontent.com/2162363/204680432-fe4b4de3-7007-42fa-b21b-919f969962da.png">
